### PR TITLE
Fix/upper limit parsing

### DIFF
--- a/interval/interval.go
+++ b/interval/interval.go
@@ -96,7 +96,7 @@ func Parse[T Numeric](input string) (Interval[T], error) {
 	maxIsOpen := false
 	last := input[iLen-1 : iLen]
 	if last == ")" {
-		minIsOpen = true
+		maxIsOpen = true
 	} else if last != "]" {
 		return Interval[T]{}, errors.New(fmt.Sprintf("invalid input max limit %s : %s", last, input))
 	}


### PR DESCRIPTION
fixes an issue where the upper limit was detected as closed even if the value ")" was given